### PR TITLE
Update stages.py

### DIFF
--- a/pkgs/clean-pkg/src/genie/libs/clean/stages/iosxe/stages.py
+++ b/pkgs/clean-pkg/src/genie/libs/clean/stages/iosxe/stages.py
@@ -317,7 +317,7 @@ def tftp_boot(section, steps, device, ip_address, subnet_mask, gateway,
         # to the device. Cannot use device.reload() directly as in case of HA,
         # we need both sup to do the commands
         device.sendline('reload')
-        device.sendline('yes')
+        device.sendline('no')
         device.sendline()
 
         # We now want to overwrite the statemachine


### PR DESCRIPTION
In tftp_boot changed line 320 from device.sendline('yes') to device.sendline('no').  We do not want existing configuration to be saved before reloading router.