### PR TITLE
initial commit for pull req

### DIFF
--- a/pkgs/clean-pkg/src/genie/libs/clean/stages/iosxr/stages.py
+++ b/pkgs/clean-pkg/src/genie/libs/clean/stages/iosxr/stages.py
@@ -494,9 +494,13 @@ install_image_and_packages:
                     error_pattern=self.error_patterns)
 
                 out = device.expect(
-                    [self.successful_operation_string],
+                    [self.successful_operation_string, self.install_operation_aborted_pattern],
                     trim_buffer=False,
                     timeout=install_timeout)
+                error = re.search(self.install_operation_aborted_pattern, out.match_output)
+                if error:
+                        device.execute("show install log " + error.groupdict()['id'])
+                        step.failed("The command '{cmd}' aborted ".format(cmd=cmd))
             except Exception as e:
                 step.failed("The command '{cmd}' failed. Error: {e}"
                             .format(cmd=cmd, e=str(e)))
@@ -538,9 +542,14 @@ install_image_and_packages:
                     device.spawn, timeout=install_timeout)
 
                 # Wait for successful output
-                device.expect(
-                    [self.successful_operation_string],
+                out = device.expect(
+                    [self.successful_operation_string, self.install_operation_aborted_pattern],
+                    trim_buffer=False,
                     timeout=install_timeout)
+                error = re.search(self.install_operation_aborted_pattern, out.match_output)
+                if error:
+                        device.execute("show install log " + error.groupdict()['id'])
+                        step.failed("The command '{cmd}' aborted ".format(cmd=cmd))
             except Exception as e:
                 step.failed("Attempting to activate install id '{id}' "
                             "failed. Error: {e}"


### PR DESCRIPTION
Hello,

This small change in the XR Clean InstallImagesAndPackages should ease the error detection for steps "install add" and "install activate". 
In recent software, these modes are launched by default with 'synchronous' keyword that block the user session during the install operation (no prompt). Errors were detected via the device.execute(error_pattern=...) syntax.

However, with older softwares (XR < 7) these install ops are launched in the background and the initial code was expecting only success answers with the device.expect() syntax. When "install add/activate" failed in the background, the error message was not catched by the stage and the script waited the timeout. 

With this change, we should be able to handle both cases. I tried to keep it coherent with the previous code in the previous steps. Also, I prefered to make the entire stage fail (by failing a step) when install add/activate fail instead of continuing for nothing.