### PR TITLE
Wrong documentation for clear counters

### DIFF
--- a/pkgs/sdk-pkg/src/genie/libs/sdk/apis/iosxe/dhcp/configure.py
+++ b/pkgs/sdk-pkg/src/genie/libs/sdk/apis/iosxe/dhcp/configure.py
@@ -18,6 +18,9 @@ def create_dhcp_pool(
             network ('str'): IP of the network pool
             mask ('str'): Subnet mask of the network pool
             router_id ('str'): Default router ID
+            lease_days ('str'): Number of days for the lease
+            lease_hrs ('str'): Number of hours for the lease
+            lease_mins ('str'): Number of minutes for the lease
         Returns:
             None
         Raises:

--- a/pkgs/sdk-pkg/src/genie/libs/sdk/apis/iosxe/dhcp/configure.py
+++ b/pkgs/sdk-pkg/src/genie/libs/sdk/apis/iosxe/dhcp/configure.py
@@ -18,9 +18,6 @@ def create_dhcp_pool(
             network ('str'): IP of the network pool
             mask ('str'): Subnet mask of the network pool
             router_id ('str'): Default router ID
-            lease_days ('str'): Number of days for the lease
-            lease_hrs ('str'): Number of hours for the lease
-            lease_mins ('str'): Number of minutes for the lease
         Returns:
             None
         Raises:

--- a/pkgs/sdk-pkg/src/genie/libs/sdk/apis/iosxe/utils.py
+++ b/pkgs/sdk-pkg/src/genie/libs/sdk/apis/iosxe/utils.py
@@ -751,7 +751,7 @@ def get_show_output_line_count(device, command, filter, output=None):
 
 
 def clear_counters(device):
-    """ clear logging
+    """ clear counters
         Args:
             device ('obj'): Device object
         Returns:


### PR DESCRIPTION
**Issue Description:**
In the [pubhub documentation for clear_counters](https://pubhub.devnetcloud.com/media/genie-feature-browser/docs/#/apis/clear_counters) the headline is wrong and says clear logging instead.

**Changes:**
Switching clear logging with clear counters.

**Unit Testing:**
None required, changes only affect comment part.