### PR TITLE
Missing Switchport

### DIFF
--- a/pkgs/sdk-pkg/src/genie/libs/sdk/apis/iosxe/interface/configure.py
+++ b/pkgs/sdk-pkg/src/genie/libs/sdk/apis/iosxe/interface/configure.py
@@ -1217,6 +1217,7 @@ def configure_interface_switchport_access_vlan(device, interface, vlan,mode=None
 
     config_list = []
     config_list.append("interface {interface}".format(interface=interface))
+    config_list.append("switchport")
     if mode:
         config_list.append("switchport mode {mode}".format(mode=mode))
     config_list.append("switchport access vlan {vlan}".format(vlan=vlan))


### PR DESCRIPTION
# Description
When configuring an access switchport the switchport command is missing. 
```configure_interface_switchport_access_vlan``` 

# Root Cause
If this function is called when transitioning from L3 port to L2 port it will fail, because the port won't be in switchport prior to that.
I've added switchport to make that transition smooth, the switchport configuration is not new, it's used in ```configure_interface_switchport_trunk``` , ```configure_switchport_trunk```, ```configure_switchport_trunk_allowed_vlan```