### PR TITLE
added null checks in configure_common_criteria_policy(aaa)

### DIFF
--- a/pkgs/sdk-pkg/src/genie/libs/sdk/apis/iosxe/aaa/configure.py
+++ b/pkgs/sdk-pkg/src/genie/libs/sdk/apis/iosxe/aaa/configure.py
@@ -921,9 +921,9 @@ def configure_common_criteria_policy(device,
     if lifetime:
        for key in lifetime:
            configs.append("lifetime {attr} {val}".format(attr=key, val=lifetime[key]))
-    if int(lower_case) > 0:
+    if lower_case and int(lower_case) > 0:
         configs.append("lower-case {low}".format(low=lower_case))
-    if int(upper_case) > 0:
+    if upper_case and int(upper_case) > 0:
         configs.append("upper-case {up}".format(up=upper_case))
     if max_len:
         configs.append("max-length {maxl}".format(maxl=max_len))
@@ -938,7 +938,7 @@ def configure_common_criteria_policy(device,
             for key in no_value:
                 configs.append("no {attr} {val}".format(attr=key,
                     val=no_value[key]))
-    if int(num_count) > 0:
+    if num_count and int(num_count) > 0:
         configs.append("numeric-count {num}".format(num=num_count))
     if special_case:
         configs.append("special-case {spcl}".format(spcl=special_case))

--- a/pkgs/sdk-pkg/src/genie/libs/sdk/apis/tests/iosxe/aaa/configure/configure_common_criteria_policy/test_api_configure_common_criteria_policy.py
+++ b/pkgs/sdk-pkg/src/genie/libs/sdk/apis/tests/iosxe/aaa/configure/configure_common_criteria_policy/test_api_configure_common_criteria_policy.py
@@ -1,4 +1,3 @@
-import os
 import unittest
 from pyats.topology import loader
 from genie.libs.sdk.apis.iosxe.aaa.configure import configure_common_criteria_policy

--- a/pkgs/sdk-pkg/src/genie/libs/sdk/apis/tests/iosxe/aaa/configure/configure_common_criteria_policy/test_api_configure_common_criteria_policy.py
+++ b/pkgs/sdk-pkg/src/genie/libs/sdk/apis/tests/iosxe/aaa/configure/configure_common_criteria_policy/test_api_configure_common_criteria_policy.py
@@ -3,8 +3,37 @@ import unittest
 from pyats.topology import loader
 from genie.libs.sdk.apis.iosxe.aaa.configure import configure_common_criteria_policy
 
-
 class TestConfigureCommonCriteriaPolicy(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(self):
+        testbed = f"""
+        devices:
+          Router:
+            connections:
+              defaults:
+                class: unicon.Unicon
+              a:
+                command: mock_device_cli --os iosxe --mock_data_dir {os.path.dirname(__file__)}/mock_data --state connect
+                protocol: unknown
+            os: iosxe
+            platform: vwlc
+            type: wlc
+        """
+        self.testbed = loader.load(testbed)
+        self.device = self.testbed.devices['Router']
+        self.device.connect(
+            learn_hostname=True,
+            init_config_commands=[],
+            init_exec_commands=[]
+        )
+
+    def test_configure_common_criteria_policy(self):
+        result = configure_common_criteria_policy(self.device, 'ABCD', None, None, None, None, None, None, 1, None, None, None, False, None)
+        expected_output = None
+        self.assertEqual(result, expected_output)
+
+class TestConfigureCommonCriteriaPolicyBase(unittest.TestCase):
 
     @classmethod
     def setUpClass(self):

--- a/pkgs/sdk-pkg/src/genie/libs/sdk/apis/tests/iosxe/aaa/configure/configure_common_criteria_policy/test_api_configure_common_criteria_policy.py
+++ b/pkgs/sdk-pkg/src/genie/libs/sdk/apis/tests/iosxe/aaa/configure/configure_common_criteria_policy/test_api_configure_common_criteria_policy.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 from pyats.topology import loader
 from genie.libs.sdk.apis.iosxe.aaa.configure import configure_common_criteria_policy
@@ -7,21 +8,21 @@ class TestConfigureCommonCriteriaPolicy(unittest.TestCase):
 
     @classmethod
     def setUpClass(self):
-        testbed = """
+        testbed = f"""
         devices:
-          VTP-PK1:
+          Router:
             connections:
               defaults:
                 class: unicon.Unicon
               a:
-                command: mock_device_cli --os iosxe --mock_data_dir mock_data --state connect
+                command: mock_device_cli --os iosxe --mock_data_dir {os.path.dirname(__file__)}/mock_data --state connect
                 protocol: unknown
             os: iosxe
-            platform: cat9k
-            type: c9200
+            platform: vwlc
+            type: wlc
         """
         self.testbed = loader.load(testbed)
-        self.device = self.testbed.devices['VTP-PK1']
+        self.device = self.testbed.devices['Router']
         self.device.connect(
             learn_hostname=True,
             init_config_commands=[],
@@ -29,6 +30,6 @@ class TestConfigureCommonCriteriaPolicy(unittest.TestCase):
         )
 
     def test_configure_common_criteria_policy(self):
-        result = configure_common_criteria_policy(self.device, 'ABCD', 5, 0, 0, 1, 1, 20, 8, 0, 1, 5, True, 1)
+        result = configure_common_criteria_policy(self.device, 'ABCD', None, None, None, None, None, None, 1, None, None, None, False, None)
         expected_output = None
         self.assertEqual(result, expected_output)

--- a/pkgs/sdk-pkg/src/genie/libs/sdk/apis/tests/iosxe/aaa/configure/configure_common_criteria_policy/test_api_configure_common_criteria_policy.py
+++ b/pkgs/sdk-pkg/src/genie/libs/sdk/apis/tests/iosxe/aaa/configure/configure_common_criteria_policy/test_api_configure_common_criteria_policy.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 from pyats.topology import loader
 from genie.libs.sdk.apis.iosxe.aaa.configure import configure_common_criteria_policy

--- a/pkgs/sdk-pkg/src/genie/libs/sdk/apis/tests/iosxe/aaa/configure/configure_common_criteria_policy/test_api_configure_common_criteria_policy.py
+++ b/pkgs/sdk-pkg/src/genie/libs/sdk/apis/tests/iosxe/aaa/configure/configure_common_criteria_policy/test_api_configure_common_criteria_policy.py
@@ -7,21 +7,21 @@ class TestConfigureCommonCriteriaPolicy(unittest.TestCase):
 
     @classmethod
     def setUpClass(self):
-        testbed = f"""
+        testbed = """
         devices:
-          Router:
+          VTP-PK1:
             connections:
               defaults:
                 class: unicon.Unicon
               a:
-                command: mock_device_cli --os iosxe --mock_data_dir {os.path.dirname(__file__)}/mock_data --state connect
+                command: mock_device_cli --os iosxe --mock_data_dir mock_data --state connect
                 protocol: unknown
             os: iosxe
-            platform: vwlc
-            type: wlc
+            platform: cat9k
+            type: c9200
         """
         self.testbed = loader.load(testbed)
-        self.device = self.testbed.devices['Router']
+        self.device = self.testbed.devices['VTP-PK1']
         self.device.connect(
             learn_hostname=True,
             init_config_commands=[],
@@ -29,7 +29,7 @@ class TestConfigureCommonCriteriaPolicy(unittest.TestCase):
         )
 
     def test_configure_common_criteria_policy(self):
-        result = configure_common_criteria_policy(self.device, 'ABCD', None, None, None, None, None, None, 1, None, None, None, False, None)
+        result = configure_common_criteria_policy(self.device, 'ABCD', 5, 0, 0, 1, 1, 20, 8, 0, 1, 5, True, 1)
         expected_output = None
         self.assertEqual(result, expected_output)
 

--- a/pkgs/sdk-pkg/src/genie/libs/sdk/apis/tests/iosxe/aaa/configure/configure_common_criteria_policy/test_api_configure_common_criteria_policy.py
+++ b/pkgs/sdk-pkg/src/genie/libs/sdk/apis/tests/iosxe/aaa/configure/configure_common_criteria_policy/test_api_configure_common_criteria_policy.py
@@ -3,6 +3,7 @@ import unittest
 from pyats.topology import loader
 from genie.libs.sdk.apis.iosxe.aaa.configure import configure_common_criteria_policy
 
+
 class TestConfigureCommonCriteriaPolicy(unittest.TestCase):
 
     @classmethod


### PR DESCRIPTION
Fixes #179 

**```uut.api.configure_common_criteria_policy(policy)```**

Error before changes:

```
2024-09-27T13:39:30: %AETEST-ERROR: Caught an exception while executing section configure_policy:
2024-09-27T13:39:30: %AETEST-ERROR: Traceback (most recent call last):
2024-09-27T13:39:30: %AETEST-ERROR:   File "/nobackup/adivardh/teacat_practice/user_missing.py", line 59, in configure_policy
2024-09-27T13:39:30: %AETEST-ERROR:     uut.api.configure_common_criteria_policy(policy)
2024-09-27T13:39:30: %AETEST-ERROR:   File "/nobackup/adivardh/pyats/lib/python3.8/site-packages/genie/conf/base/api.py", line 206, in wrapper_match
2024-09-27T13:39:30: %AETEST-ERROR:     func_result = func(*args, **kwargs)
2024-09-27T13:39:30: %AETEST-ERROR:   File "/nobackup/adivardh/pyats/lib/python3.8/site-packages/genie/libs/sdk/apis/iosxe/aaa/configure.py", line 924, in configure_common_criteria_policy
2024-09-27T13:39:30: %AETEST-ERROR:     if int(lower_case) > 0:
2024-09-27T13:39:30: %AETEST-ERROR: TypeError: int() argument must be a string, a bytes-like object or a number, not 'NoneType'
```

After the changes:

```
2024-09-27 13:44:40,146: %UNICON-INFO: +++ Router(alias=uut) with via 'a': configure +++
config term
Enter configuration commands, one per line.  End with CNTL/Z.
Router(config)#aaa common-criteria policy POLICY
Router(config-cc-policy)#end
Router#

```
