### PR TITLE
Configure username

### DIFF
--- a/pkgs/sdk-pkg/src/genie/libs/sdk/apis/iosxe/aaa/configure.py
+++ b/pkgs/sdk-pkg/src/genie/libs/sdk/apis/iosxe/aaa/configure.py
@@ -921,9 +921,9 @@ def configure_common_criteria_policy(device,
     if lifetime:
        for key in lifetime:
            configs.append("lifetime {attr} {val}".format(attr=key, val=lifetime[key]))
-    if int(lower_case) > 0:
+    if lower_case and int(lower_case) > 0:
         configs.append("lower-case {low}".format(low=lower_case))
-    if int(upper_case) > 0:
+    if upper_case and int(upper_case) > 0:
         configs.append("upper-case {up}".format(up=upper_case))
     if max_len:
         configs.append("max-length {maxl}".format(maxl=max_len))
@@ -938,7 +938,7 @@ def configure_common_criteria_policy(device,
             for key in no_value:
                 configs.append("no {attr} {val}".format(attr=key,
                     val=no_value[key]))
-    if int(num_count) > 0:
+    if num_count and int(num_count) > 0:
         configs.append("numeric-count {num}".format(num=num_count))
     if special_case:
         configs.append("special-case {spcl}".format(spcl=special_case))

--- a/pkgs/sdk-pkg/src/genie/libs/sdk/apis/iosxe/aaa/configure.py
+++ b/pkgs/sdk-pkg/src/genie/libs/sdk/apis/iosxe/aaa/configure.py
@@ -939,9 +939,9 @@ def configure_common_criteria_policy(device,
     if lifetime:
        for key in lifetime:
            configs.append("lifetime {attr} {val}".format(attr=key, val=lifetime[key]))
-    if lower_case and int(lower_case) > 0:
+    if int(lower_case) > 0:
         configs.append("lower-case {low}".format(low=lower_case))
-    if upper_case and int(upper_case) > 0:
+    if int(upper_case) > 0:
         configs.append("upper-case {up}".format(up=upper_case))
     if max_len:
         configs.append("max-length {maxl}".format(maxl=max_len))
@@ -956,7 +956,7 @@ def configure_common_criteria_policy(device,
             for key in no_value:
                 configs.append("no {attr} {val}".format(attr=key,
                     val=no_value[key]))
-    if num_count and int(num_count) > 0:
+    if int(num_count) > 0:
         configs.append("numeric-count {num}".format(num=num_count))
     if special_case:
         configs.append("special-case {spcl}".format(spcl=special_case))

--- a/pkgs/sdk-pkg/src/genie/libs/sdk/apis/tests/iosxe/aaa/configure/configure_common_criteria_policy/test_api_configure_common_criteria_policy.py
+++ b/pkgs/sdk-pkg/src/genie/libs/sdk/apis/tests/iosxe/aaa/configure/configure_common_criteria_policy/test_api_configure_common_criteria_policy.py
@@ -1,4 +1,3 @@
-import os
 import unittest
 from pyats.topology import loader
 from genie.libs.sdk.apis.iosxe.aaa.configure import configure_common_criteria_policy

--- a/pkgs/sdk-pkg/src/genie/libs/sdk/apis/tests/iosxe/aaa/configure/configure_common_criteria_policy/test_api_configure_common_criteria_policy.py
+++ b/pkgs/sdk-pkg/src/genie/libs/sdk/apis/tests/iosxe/aaa/configure/configure_common_criteria_policy/test_api_configure_common_criteria_policy.py
@@ -3,8 +3,37 @@ import unittest
 from pyats.topology import loader
 from genie.libs.sdk.apis.iosxe.aaa.configure import configure_common_criteria_policy
 
-
 class TestConfigureCommonCriteriaPolicy(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(self):
+        testbed = f"""
+        devices:
+          Router:
+            connections:
+              defaults:
+                class: unicon.Unicon
+              a:
+                command: mock_device_cli --os iosxe --mock_data_dir {os.path.dirname(__file__)}/mock_data --state connect
+                protocol: unknown
+            os: iosxe
+            platform: vwlc
+            type: wlc
+        """
+        self.testbed = loader.load(testbed)
+        self.device = self.testbed.devices['Router']
+        self.device.connect(
+            learn_hostname=True,
+            init_config_commands=[],
+            init_exec_commands=[]
+        )
+
+    def test_configure_common_criteria_policy(self):
+        result = configure_common_criteria_policy(self.device, 'ABCD', None, None, None, None, None, None, 1, None, None, None, False, None)
+        expected_output = None
+        self.assertEqual(result, expected_output)
+
+class TestConfigureCommonCriteriaPolicyBase(unittest.TestCase):
 
     @classmethod
     def setUpClass(self):

--- a/pkgs/sdk-pkg/src/genie/libs/sdk/apis/tests/iosxe/aaa/configure/configure_common_criteria_policy/test_api_configure_common_criteria_policy.py
+++ b/pkgs/sdk-pkg/src/genie/libs/sdk/apis/tests/iosxe/aaa/configure/configure_common_criteria_policy/test_api_configure_common_criteria_policy.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 from pyats.topology import loader
 from genie.libs.sdk.apis.iosxe.aaa.configure import configure_common_criteria_policy
@@ -7,21 +8,21 @@ class TestConfigureCommonCriteriaPolicy(unittest.TestCase):
 
     @classmethod
     def setUpClass(self):
-        testbed = """
+        testbed = f"""
         devices:
-          VTP-PK1:
+          Router:
             connections:
               defaults:
                 class: unicon.Unicon
               a:
-                command: mock_device_cli --os iosxe --mock_data_dir mock_data --state connect
+                command: mock_device_cli --os iosxe --mock_data_dir {os.path.dirname(__file__)}/mock_data --state connect
                 protocol: unknown
             os: iosxe
-            platform: cat9k
-            type: c9200
+            platform: vwlc
+            type: wlc
         """
         self.testbed = loader.load(testbed)
-        self.device = self.testbed.devices['VTP-PK1']
+        self.device = self.testbed.devices['Router']
         self.device.connect(
             learn_hostname=True,
             init_config_commands=[],
@@ -29,6 +30,6 @@ class TestConfigureCommonCriteriaPolicy(unittest.TestCase):
         )
 
     def test_configure_common_criteria_policy(self):
-        result = configure_common_criteria_policy(self.device, 'ABCD', 5, 0, 0, 1, 1, 20, 8, 0, 1, 5, True, 1)
+        result = configure_common_criteria_policy(self.device, 'ABCD', None, None, None, None, None, None, 1, None, None, None, False, None)
         expected_output = None
         self.assertEqual(result, expected_output)

--- a/pkgs/sdk-pkg/src/genie/libs/sdk/apis/tests/iosxe/aaa/configure/configure_common_criteria_policy/test_api_configure_common_criteria_policy.py
+++ b/pkgs/sdk-pkg/src/genie/libs/sdk/apis/tests/iosxe/aaa/configure/configure_common_criteria_policy/test_api_configure_common_criteria_policy.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 from pyats.topology import loader
 from genie.libs.sdk.apis.iosxe.aaa.configure import configure_common_criteria_policy

--- a/pkgs/sdk-pkg/src/genie/libs/sdk/apis/tests/iosxe/aaa/configure/configure_common_criteria_policy/test_api_configure_common_criteria_policy.py
+++ b/pkgs/sdk-pkg/src/genie/libs/sdk/apis/tests/iosxe/aaa/configure/configure_common_criteria_policy/test_api_configure_common_criteria_policy.py
@@ -7,21 +7,21 @@ class TestConfigureCommonCriteriaPolicy(unittest.TestCase):
 
     @classmethod
     def setUpClass(self):
-        testbed = f"""
+        testbed = """
         devices:
-          Router:
+          VTP-PK1:
             connections:
               defaults:
                 class: unicon.Unicon
               a:
-                command: mock_device_cli --os iosxe --mock_data_dir {os.path.dirname(__file__)}/mock_data --state connect
+                command: mock_device_cli --os iosxe --mock_data_dir mock_data --state connect
                 protocol: unknown
             os: iosxe
-            platform: vwlc
-            type: wlc
+            platform: cat9k
+            type: c9200
         """
         self.testbed = loader.load(testbed)
-        self.device = self.testbed.devices['Router']
+        self.device = self.testbed.devices['VTP-PK1']
         self.device.connect(
             learn_hostname=True,
             init_config_commands=[],
@@ -29,7 +29,7 @@ class TestConfigureCommonCriteriaPolicy(unittest.TestCase):
         )
 
     def test_configure_common_criteria_policy(self):
-        result = configure_common_criteria_policy(self.device, 'ABCD', None, None, None, None, None, None, 1, None, None, None, False, None)
+        result = configure_common_criteria_policy(self.device, 'ABCD', 5, 0, 0, 1, 1, 20, 8, 0, 1, 5, True, 1)
         expected_output = None
         self.assertEqual(result, expected_output)
 

--- a/pkgs/sdk-pkg/src/genie/libs/sdk/apis/tests/iosxe/aaa/configure/configure_common_criteria_policy/test_api_configure_common_criteria_policy.py
+++ b/pkgs/sdk-pkg/src/genie/libs/sdk/apis/tests/iosxe/aaa/configure/configure_common_criteria_policy/test_api_configure_common_criteria_policy.py
@@ -33,33 +33,3 @@ class TestConfigureCommonCriteriaPolicy(unittest.TestCase):
         result = configure_common_criteria_policy(self.device, 'ABCD', 5, 0, 0, 1, 1, 20, 8, 0, 1, 5, True, 1)
         expected_output = None
         self.assertEqual(result, expected_output)
-
-class TestConfigureCommonCriteriaPolicyBase(unittest.TestCase):
-
-    @classmethod
-    def setUpClass(self):
-        testbed = f"""
-        devices:
-          Router:
-            connections:
-              defaults:
-                class: unicon.Unicon
-              a:
-                command: mock_device_cli --os iosxe --mock_data_dir {os.path.dirname(__file__)}/mock_data --state connect
-                protocol: unknown
-            os: iosxe
-            platform: vwlc
-            type: wlc
-        """
-        self.testbed = loader.load(testbed)
-        self.device = self.testbed.devices['Router']
-        self.device.connect(
-            learn_hostname=True,
-            init_config_commands=[],
-            init_exec_commands=[]
-        )
-
-    def test_configure_common_criteria_policy(self):
-        result = configure_common_criteria_policy(self.device, 'ABCD', None, None, None, None, None, None, 1, None, None, None, False, None)
-        expected_output = None
-        self.assertEqual(result, expected_output)

--- a/pkgs/sdk-pkg/src/genie/libs/sdk/apis/tests/iosxe/aaa/configure/configure_common_criteria_policy/test_api_configure_common_criteria_policy.py
+++ b/pkgs/sdk-pkg/src/genie/libs/sdk/apis/tests/iosxe/aaa/configure/configure_common_criteria_policy/test_api_configure_common_criteria_policy.py
@@ -3,6 +3,7 @@ import unittest
 from pyats.topology import loader
 from genie.libs.sdk.apis.iosxe.aaa.configure import configure_common_criteria_policy
 
+
 class TestConfigureCommonCriteriaPolicy(unittest.TestCase):
 
     @classmethod

--- a/pkgs/sdk-pkg/src/genie/libs/sdk/apis/tests/iosxe/aaa/configure/configure_username/mock_data/iosxe/mock_data.yaml
+++ b/pkgs/sdk-pkg/src/genie/libs/sdk/apis/tests/iosxe/aaa/configure/configure_username/mock_data/iosxe/mock_data.yaml
@@ -5,24 +5,32 @@ configure:
     line console 0:
       new_state: configure_line
     no logging console: ''
-    username test privilege 1 password lab: |
-      username test privilege 1 password lab
-       WARNING: Command has been added to the configuration using a type 0 password. However, recommended to migrate to strong type-6 encryption
-  prompt: Switch-9300(config)#
+    username USER privilege 15 view VIEW common-criteria-policy POLICY secret test: "username\
+      \ USER privilege 15 view VIEW common-criteri\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\
+      \b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b$ER privilege\
+      \ 15 view VIEW common-criteria         \b\b\b\b\b\b\b\b\b-policy P\b\b\b\b\b\
+      \b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\
+      \b\b\b\b\b\b\bge 15 view VIEW common-criteria-policy PO         \b\b\b\b\b\b\
+      \b\b\bLICY secr\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\
+      \b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b VIEW common-criteria-policy POLICY secre\
+      \         \b\b\b\b\b\b\b\b\bt test\r\n% CC policy \"POLICY\" not found in policy\
+      \ map\r\n"
+  prompt: yang-infra-c8kv-3(config)#
 configure_line:
   commands:
     end:
       new_state: execute
     exec-timeout 0: ''
-  prompt: Switch-9300(config-line)#
+  prompt: yang-infra-c8kv-3(config-line)#
 connect:
   commands:
-    '':
-      new_state: execute
-  preface: |-
-    Trying mock_device ...
+    ? ''
+    : new_state: execute
+  preface: 'Trying mock_device ...
+
     Connected to mock_device.
-    Escape character is '^]'.
+
+    Escape character is ''^]''.'
   prompt: ''
 execute:
   commands:
@@ -31,7 +39,7 @@ execute:
     config-transaction:
       new_state: configure
     show version: ''
+    show version | include operating mode: ''
     term length 0: ''
     term width 0: ''
-    show version | include operating mode: ''
-  prompt: Switch-9300#
+  prompt: yang-infra-c8kv-3#

--- a/pkgs/sdk-pkg/src/genie/libs/sdk/apis/tests/iosxe/aaa/configure/configure_username/mock_data/iosxe/mock_data.yaml
+++ b/pkgs/sdk-pkg/src/genie/libs/sdk/apis/tests/iosxe/aaa/configure/configure_username/mock_data/iosxe/mock_data.yaml
@@ -5,32 +5,24 @@ configure:
     line console 0:
       new_state: configure_line
     no logging console: ''
-    username USER privilege 15 view VIEW common-criteria-policy POLICY secret test: "username\
-      \ USER privilege 15 view VIEW common-criteri\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\
-      \b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b$ER privilege\
-      \ 15 view VIEW common-criteria         \b\b\b\b\b\b\b\b\b-policy P\b\b\b\b\b\
-      \b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\
-      \b\b\b\b\b\b\bge 15 view VIEW common-criteria-policy PO         \b\b\b\b\b\b\
-      \b\b\bLICY secr\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\
-      \b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b VIEW common-criteria-policy POLICY secre\
-      \         \b\b\b\b\b\b\b\b\bt test\r\n% CC policy \"POLICY\" not found in policy\
-      \ map\r\n"
-  prompt: yang-infra-c8kv-3(config)#
+    username test privilege 1 password lab: |
+      username test privilege 1 password lab
+       WARNING: Command has been added to the configuration using a type 0 password. However, recommended to migrate to strong type-6 encryption
+  prompt: Switch-9300(config)#
 configure_line:
   commands:
     end:
       new_state: execute
     exec-timeout 0: ''
-  prompt: yang-infra-c8kv-3(config-line)#
+  prompt: Switch-9300(config-line)#
 connect:
   commands:
-    ? ''
-    : new_state: execute
-  preface: 'Trying mock_device ...
-
+    '':
+      new_state: execute
+  preface: |-
+    Trying mock_device ...
     Connected to mock_device.
-
-    Escape character is ''^]''.'
+    Escape character is '^]'.
   prompt: ''
 execute:
   commands:
@@ -39,7 +31,7 @@ execute:
     config-transaction:
       new_state: configure
     show version: ''
-    show version | include operating mode: ''
     term length 0: ''
     term width 0: ''
-  prompt: yang-infra-c8kv-3#
+    show version | include operating mode: ''
+  prompt: Switch-9300#

--- a/pkgs/sdk-pkg/src/genie/libs/sdk/apis/tests/iosxe/aaa/configure/configure_username/mock_data_secret/iosxe/mock_data_secret.yaml
+++ b/pkgs/sdk-pkg/src/genie/libs/sdk/apis/tests/iosxe/aaa/configure/configure_username/mock_data_secret/iosxe/mock_data_secret.yaml
@@ -1,0 +1,45 @@
+configure:
+  commands:
+    end:
+      new_state: execute
+    line console 0:
+      new_state: configure_line
+    no logging console: ''
+    username USER privilege 15 view VIEW common-criteria-policy POLICY secret test: "username\
+      \ USER privilege 15 view VIEW common-criteri\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\
+      \b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b$ER privilege\
+      \ 15 view VIEW common-criteria         \b\b\b\b\b\b\b\b\b-policy P\b\b\b\b\b\
+      \b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\
+      \b\b\b\b\b\b\bge 15 view VIEW common-criteria-policy PO         \b\b\b\b\b\b\
+      \b\b\bLICY secr\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\
+      \b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b VIEW common-criteria-policy POLICY secre\
+      \         \b\b\b\b\b\b\b\b\bt test\r\n% CC policy \"POLICY\" not found in policy\
+      \ map\r\n"
+  prompt: yang-infra-c8kv-3(config)#
+configure_line:
+  commands:
+    end:
+      new_state: execute
+    exec-timeout 0: ''
+  prompt: yang-infra-c8kv-3(config-line)#
+connect:
+  commands:
+    ? ''
+    : new_state: execute
+  preface: 'Trying mock_device ...
+
+    Connected to mock_device.
+
+    Escape character is ''^]''.'
+  prompt: ''
+execute:
+  commands:
+    config term:
+      new_state: configure
+    config-transaction:
+      new_state: configure
+    show version: ''
+    show version | include operating mode: ''
+    term length 0: ''
+    term width 0: ''
+  prompt: yang-infra-c8kv-3#

--- a/pkgs/sdk-pkg/src/genie/libs/sdk/apis/tests/iosxe/aaa/configure/configure_username/test_api_configure_username.py
+++ b/pkgs/sdk-pkg/src/genie/libs/sdk/apis/tests/iosxe/aaa/configure/configure_username/test_api_configure_username.py
@@ -30,7 +30,7 @@ class TestConfigureUsername(unittest.TestCase):
         )
 
     def test_configure_username(self):
-        result = configure_username(self.device, 'test', 'lab', privilege=1)
+        result = configure_username(self.device, 'test', 'lab', '1')
         expected_output = None
         self.assertEqual(result, expected_output)
 

--- a/pkgs/sdk-pkg/src/genie/libs/sdk/apis/tests/iosxe/aaa/configure/configure_username/test_api_configure_username.py
+++ b/pkgs/sdk-pkg/src/genie/libs/sdk/apis/tests/iosxe/aaa/configure/configure_username/test_api_configure_username.py
@@ -30,6 +30,36 @@ class TestConfigureUsername(unittest.TestCase):
         )
 
     def test_configure_username(self):
-        result = configure_username(self.device, 'test', 'lab', 0, '1')
+        result = configure_username(self.device, 'test', 'lab', privilege=1)
+        expected_output = None
+        self.assertEqual(result, expected_output)
+
+class TestConfigureUsernameSecret(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(self):
+        testbed = f"""
+        devices:
+          yang-infra-c8kv-3:
+            connections:
+              defaults:
+                class: unicon.Unicon
+              a:
+                command: mock_device_cli --os iosxe --mock_data_dir {os.path.dirname(__file__)}/mock_data --state connect
+                protocol: unknown
+            os: iosxe
+            platform: vwlc
+            type: wlc
+        """
+        self.testbed = loader.load(testbed)
+        self.device = self.testbed.devices['yang-infra-c8kv-3']
+        self.device.connect(
+            learn_hostname=True,
+            init_config_commands=[],
+            init_exec_commands=[]
+        )
+
+    def test_configure_username(self):
+        result = configure_username(self.device, 'USER', '', 0, 15, 'VIEW', 'common-criteria-policy', 'POLICY', 'test')
         expected_output = None
         self.assertEqual(result, expected_output)

--- a/pkgs/sdk-pkg/src/genie/libs/sdk/apis/tests/iosxe/aaa/configure/configure_username/test_api_configure_username.py
+++ b/pkgs/sdk-pkg/src/genie/libs/sdk/apis/tests/iosxe/aaa/configure/configure_username/test_api_configure_username.py
@@ -30,7 +30,7 @@ class TestConfigureUsername(unittest.TestCase):
         )
 
     def test_configure_username(self):
-        result = configure_username(self.device, 'test', 'lab', '1')
+        result = configure_username(self.device, 'test', 'lab', privilege=1)
         expected_output = None
         self.assertEqual(result, expected_output)
 
@@ -45,7 +45,7 @@ class TestConfigureUsernameSecret(unittest.TestCase):
               defaults:
                 class: unicon.Unicon
               a:
-                command: mock_device_cli --os iosxe --mock_data_dir {os.path.dirname(__file__)}/mock_data --state connect
+                command: mock_device_cli --os iosxe --mock_data_dir {os.path.dirname(__file__)}/mock_data_secret --state connect
                 protocol: unknown
             os: iosxe
             platform: vwlc


### PR DESCRIPTION
Adding support for configuring users with secret and specifying security policy for the users as well as CLI View


Attaching unit tests results:



```

(pyATS) bgl-ads-20083:/nobackup/adivardh/genie_fork/genielibs/tests/api/iosxe/aaa/configure/configure_username > python -m unittest

2024-10-07 14:55:37,265: %UNICON-INFO: +++ Switch-9300 logfile /tmp/Switch-9300-cli-20241007T145537264.log +++

2024-10-07 14:55:37,265: %UNICON-INFO: +++ Unicon plugin iosxe (unicon.internal.plugins.iosxe) +++
/nobackup/adivardh/pyATS/lib/python3.8/site-packages/unicon/bases/routers/connection.py:97: DeprecationWarning: Arguments 'username', 'enable_password','tacacs_password' and 'line_password' are now deprecated and replaced by 'credentials'.
  warnings.warn(message = "Arguments 'username', "
Trying mock_device ...
Connected to mock_device.
Escape character is '^]'.


2024-10-07 14:55:37,818: %UNICON-INFO: +++ connection to spawn: mock_device_cli --os iosxe --mock_data_dir /nobackup/adivardh/genie_fork/genielibs/pkgs/sdk-pkg/src/genie/libs/sdk/apis/tests/iosxe/aaa/configure/configure_username/mock_data --state connect, id: 139874891856960 +++

2024-10-07 14:55:37,819: %UNICON-INFO: connection to Switch-9300

Switch-9300#

2024-10-07 14:55:39,427: %UNICON-INFO: Learned hostname(s): 'Switch-9300'.

Switch-9300#

2024-10-07 14:55:39,581: %UNICON-INFO: +++ Switch-9300 with via 'a': executing command 'show version | include operating mode' +++
show version | include operating mode
Switch-9300#

2024-10-07 14:55:39,707: %UNICON-INFO: +++ initializing handle +++

2024-10-07 14:55:39,707: %UNICON-INFO: Learned hostname(s): 'Switch-9300'.

2024-10-07 14:55:39,830: %UNICON-INFO: +++ Switch-9300 with via 'a': configure +++
config term
Switch-9300(config)#username test privilege 1 password lab
username test privilege 1 password lab
 WARNING: Command has been added to the configuration using a type 0 password. However, recommended to migrate to strong type-6 encryption
Switch-9300(config)#end
Switch-9300#
.
2024-10-07 14:55:39,988: %UNICON-INFO: +++ yang-infra-c8kv-3 logfile /tmp/yang-infra-c8kv-3-cli-20241007T145539987.log +++

2024-10-07 14:55:39,988: %UNICON-INFO: +++ Unicon plugin iosxe (unicon.internal.plugins.iosxe) +++
Trying mock_device ...
Connected to mock_device.
Escape character is '^]'.


2024-10-07 14:55:40,641: %UNICON-INFO: +++ connection to spawn: mock_device_cli --os iosxe --mock_data_dir /nobackup/adivardh/genie_fork/genielibs/pkgs/sdk-pkg/src/genie/libs/sdk/apis/tests/iosxe/aaa/configure/configure_username/mock_data_secret --state connect, id: 139874892654528 +++

2024-10-07 14:55:40,641: %UNICON-INFO: connection to yang-infra-c8kv-3

yang-infra-c8kv-3#

2024-10-07 14:55:42,234: %UNICON-INFO: Learned hostname(s): 'yang-infra-c8kv-3'.

yang-infra-c8kv-3#

2024-10-07 14:55:42,403: %UNICON-INFO: +++ yang-infra-c8kv-3 with via 'a': executing command 'show version | include operating mode' +++
show version | include operating mode
yang-infra-c8kv-3#

2024-10-07 14:55:42,524: %UNICON-INFO: +++ initializing handle +++

2024-10-07 14:55:42,525: %UNICON-INFO: Learned hostname(s): 'yang-infra-c8kv-3'.

2024-10-07 14:55:42,650: %UNICON-INFO: +++ yang-infra-c8kv-3 with via 'a': configure +++
config term
yang-infra-c8kv-3(config)#username USER privilege 15 view VIEW common-criteria-policy POLICY secret test
$ VIEW common-criteria-policy POLICY secret test   
% CC policy "POLICY" not found in policy map
yang-infra-c8kv-3(config)#end
yang-infra-c8kv-3#
.
----------------------------------------------------------------------
Ran 2 tests in 6.456s

OK

```


Please let me know uf anything else is needed for the same