### PR TITLE
Added support for Sentry4 powercycler SNMP

### DIFF
--- a/pkgs/sdk-pkg/src/genie/libs/sdk/powercycler/powercyclers.py
+++ b/pkgs/sdk-pkg/src/genie/libs/sdk/powercycler/powercyclers.py
@@ -54,6 +54,14 @@ class RaritanSnmpv3PX2(BaseSNMPv3PowerCycler):
     off_state = 0
 
 
+class Sentry4SnmpPDU(BaseSNMPPowerCycler):
+    type = 'sentry4'
+    connection_type = 'snmp'
+    oid = '1.3.6.1.4.1.1718.4.1.8.5.1.2.1.1'
+    on_state = 1
+    off_state = 2
+
+
 class CyberSwitching(BaseCyberSwitchingPowerCycler):
     type = 'cyberswitching'
     connection_type = 'telnet'


### PR DESCRIPTION
Added support for Sentry4 powercycler SNMP

MIB URL: 
MIB: https://cdn10.servertech.com/assets/documents/documents/1040/original/Sentry4.mib?1689970823&_ga=2.228822303.206349957.1737525559-214946782.1737525559
Tree: https://cdn10.servertech.com/assets/documents/documents/1041/original/Sentry4OIDTree.txt?1689970897&_ga=2.152144186.206349957.1737525559-214946782.1737525559

oid :  st4OutletControlAction, 1.3.6.1.4.1.1718.4.1.8.5.1.2.1.1
 
